### PR TITLE
Fix flaky

### DIFF
--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPlanExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPlanExecutorTest.java
@@ -36,6 +36,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -83,10 +85,21 @@ public class ClusterPlanExecutorTest extends BaseQueryTest {
   @Test
   public void testGetAllStorageGroupNodes() {
     List<IStorageGroupMNode> allStorageGroupNodes = queryExecutor.getAllStorageGroupNodes();
+    List<IStorageGroupMNode> exceptedStorageGroupNodes =
+        IoTDB.metaManager.getAllStorageGroupNodes();
+    Collections.sort(allStorageGroupNodes, new MNodeComparator());
+    Collections.sort(exceptedStorageGroupNodes, new MNodeComparator());
     for (int i = 0; i < allStorageGroupNodes.size(); i++) {
       assertEquals(
-          IoTDB.metaManager.getAllStorageGroupNodes().get(i).getFullPath(),
+          exceptedStorageGroupNodes.get(i).getFullPath(),
           allStorageGroupNodes.get(i).getFullPath());
+    }
+  }
+
+  class MNodeComparator implements Comparator<IStorageGroupMNode> {
+    @Override
+    public int compare(IStorageGroupMNode a, IStorageGroupMNode b) {
+      return a.getFullPath().compareTo(b.getFullPath());
     }
   }
 


### PR DESCRIPTION
## Fixed Flaky Test


* In this PR, the flaky test in `org.apache.iotdb.cluster.query.ClusterPlanExecutorTest#testGetAllStorageGroupNodes` has been verified then fixed.

### Details

* The test `testGetAllStorageGroupNodes` retrieves all Group Nodes collected from another class called `IoTDB.metaManager` which is an instance of `MManger`. The class `MManager` applied `MTree` to store all schemas, and `MTree` instantiates `InternalMNode` (`iotdb/server/src/main/java/org/apache/iotdb/db/metadata/mnode/InternalMNode.java`) to store all the node data. In the `InternalMNode` class, the developer used [`ConcurrentHashMap`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html) to store the data in [Serializable](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html) way. However, he has not considered the factor that **the elements of a `ConcurrentHashMap` are not ordered in any particular way**. Therefore, when introducing the Non-Dex testing system, the order of all node data could be changed as the testing system changes the underlying implementation, which generated the flaky test we verified.

* To fix this flaky test, I simply reordered the two arrays which are compared by the test `testGetAllStorageGroupNodes`.

* Used `Collections` to sort `allStorageGroupNodes` and `exceptedStorageGroupNodes` (which is generated from `IoTDB.metaManager.getAllStorageGroupNodes();`).

* Applied `MNodeComparator implements Comparator<IStorageGroupMNode>` to pass [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-maven) plugin.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error 
    conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, 
    design patterns)
 - Method organization and design (how the logic is split between methods, parameters, and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<hr>

This PR has:
- [x] been self-reviewed.
    - [ ] concurrent read
    - [ ] concurrent write
    - [ ] concurrent read and write 
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. 
- [ ] added or updated version, __license__, or notice information
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious 
  for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold 
  for code coverage.
- [ ] added integration tests.
- [ ] been tested in a test IoTDB cluster.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items 
apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items 
from the checklist above are strictly necessary, but it would be very helpful if you at least 
self-review the PR. -->

<hr>

##### Key changed/added classes (or packages if there are too many classes) in this PR
